### PR TITLE
remove fixed spacing to reduce confusion between rules

### DIFF
--- a/src/client/druid.scss
+++ b/src/client/druid.scss
@@ -926,13 +926,11 @@ body {
 
 
     .rule {
-      height: 120px;
       margin-bottom: 10px;
 
       &:not(:first-child) {
         border-top: 1px solid $baseColor;
         padding-top: 8px;
-        height: 129px;
       }
       .summary {
         font-size: 16px;


### PR DESCRIPTION
**Before**

<img width="590" alt="before_" src="https://cloud.githubusercontent.com/assets/815147/18293928/a680be32-744a-11e6-9292-4a85867483a9.png">

**After**
<img width="595" alt="after_" src="https://cloud.githubusercontent.com/assets/815147/18293939/aed4056c-744a-11e6-86b6-ad3174e6fec1.png">
