### PR TITLE
handle unknown index types gracefully in iUtils

### DIFF
--- a/src/client/factories/iUtils.coffee
+++ b/src/client/factories/iUtils.coffee
@@ -2,9 +2,11 @@ moment = require '../../../bower_components/moment/min/moment.min.js'
 
 module.exports = ->
   parseTaskId: (taskId) ->
-    m = taskId.match /^((hadoop_convert_segment)|index_(hadoop|realtime|spark)|(archive))_(.+)_(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)/
+    m = taskId.match /^(?:(hadoop_convert_segment)|index_(hadoop|realtime|spark)|(archive))_(.+)_(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)/
     type = m[3]
     type ||= m[2]
+    type ||= m[1]
+
     throw Error("Can't parse #{taskId}") unless m
     {
       id: taskId

--- a/src/client/factories/iUtils.coffee
+++ b/src/client/factories/iUtils.coffee
@@ -2,15 +2,10 @@ moment = require '../../../bower_components/moment/min/moment.min.js'
 
 module.exports = ->
   parseTaskId: (taskId) ->
-    m = taskId.match /^(?:(hadoop_convert_segment)|index_(hadoop|realtime|spark)|(archive))_(.+)_(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)/
-    type = m[3]
-    type ||= m[2]
-    type ||= m[1]
-
-    throw Error("Can't parse #{taskId}") unless m
+    m = taskId.match(/^(?:(hadoop_convert_segment)|index_(hadoop|realtime|spark)|(archive))_(.+)_(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z)/) || []
     {
       id: taskId
-      type
+      type: m[3] || m[2] || m[1] || 'other'
       dataSource: m[4]
       dataTime: m[5]
     }

--- a/test/unit/factories/iUtils.spec.coffee
+++ b/test/unit/factories/iUtils.spec.coffee
@@ -1,0 +1,61 @@
+iUtilsFactory = require '../../../src/client/factories/iUtils.coffee'
+
+describe '$iUtils', () ->
+  $iUtils = undefined
+  $taskTimestamp = '2018-01-01T10:20:30.400Z'
+
+  beforeEach ->
+    $iUtils = iUtilsFactory()
+
+  it 'should have a defined $iUtils', () ->
+    expect($iUtils?).toBeTruthy()
+
+  describe 'parseTaskId', () ->
+    it 'should parse hadoop_convert task', () ->
+      task = $iUtils.parseTaskId('hadoop_convert_segment_wikipedia_' + $taskTimestamp)
+      expect(task).toEqual({
+        id: 'hadoop_convert_segment_wikipedia_' + $taskTimestamp
+        type: 'hadoop_convert_segment'
+        dataSource: 'wikipedia'
+        dataTime: $taskTimestamp
+      })
+
+    it 'should parse index_hadoop task', () ->
+      task = $iUtils.parseTaskId('index_hadoop_twitter_' + $taskTimestamp)
+      expect(task).toEqual({
+        id: 'index_hadoop_twitter_' + $taskTimestamp
+        type: 'hadoop'
+        dataSource: 'twitter'
+        dataTime: $taskTimestamp
+      })
+
+    it 'should parse index_realtime task', () ->
+      task = $iUtils.parseTaskId('index_realtime_twitter_' + $taskTimestamp)
+      expect(task).toEqual({
+        id: 'index_realtime_twitter_' + $taskTimestamp
+        type: 'realtime'
+        dataSource: 'twitter'
+        dataTime: $taskTimestamp
+      })
+
+    it 'should parse index_spark task', () ->
+      task = $iUtils.parseTaskId('index_spark_twitter_' + $taskTimestamp)
+      expect(task).toEqual({
+        id: 'index_spark_twitter_' + $taskTimestamp
+        type: 'spark'
+        dataSource: 'twitter'
+        dataTime: $taskTimestamp
+      })
+
+    it 'should parse archive task', () ->
+      task = $iUtils.parseTaskId('archive_wikipedia_' + $taskTimestamp)
+      expect(task).toEqual({
+        id: 'archive_wikipedia_' + $taskTimestamp
+        type: 'archive'
+        dataSource: 'wikipedia'
+        dataTime: $taskTimestamp
+      })
+
+    it 'should throw an error if taskId does not match expected pattern', () ->
+      expect(() -> $iUtils.parseTaskId('index_kafka_twitter_1675e770de9a423_hfdhgjko'))
+        .toThrow(new TypeError("Cannot read property '3' of null"))

--- a/test/unit/factories/iUtils.spec.coffee
+++ b/test/unit/factories/iUtils.spec.coffee
@@ -56,6 +56,11 @@ describe '$iUtils', () ->
         dataTime: $taskTimestamp
       })
 
-    it 'should throw an error if taskId does not match expected pattern', () ->
-      expect(() -> $iUtils.parseTaskId('index_kafka_twitter_1675e770de9a423_hfdhgjko'))
-        .toThrow(new TypeError("Cannot read property '3' of null"))
+    it 'should not throw an error if taskId does not match expected pattern', () ->
+      task = $iUtils.parseTaskId('index_kafka_twitter_1675e770de9a423_hfdhgjko')
+      expect(task).toEqual({
+        id: 'index_kafka_twitter_1675e770de9a423_hfdhgjko'
+        type: 'other'
+        dataSource: undefined
+        dataTime: undefined
+      })


### PR DESCRIPTION
this updates `parseTaskId` in `iUtils.coffee` which uses a somwhat strict regular expression to parse a given task id and extract `type`, `datasource`, and time (relates to #3 and #9).

this simply removes throwing the error and falls back to `'other'` for type leaving `dataSource` and `dataTime` alone. in case of a match failure, they would just default to undefined which isn't a blocker to render `/indexing-service` view.