### PR TITLE
fix rule priority hint

### DIFF
--- a/static/pages/rules.html
+++ b/static/pages/rules.html
@@ -98,8 +98,8 @@
 
             <div>
               <div class="btn-group-vertical btn-group-sm">
-                <button class="btn btn-info" ng-click="moveRule($index, -1)" ng-disabled="$first" title="decrease this rule's priority"><span class="fa fa-arrow-up fa-lg"></span></button>
-                <button class="btn btn-info" ng-click="moveRule($index, 1)" ng-disabled="$last" title="increase this rule's priority"><span class="fa fa-arrow-down fa-lg"></span></button>
+                <button class="btn btn-info" ng-click="moveRule($index, -1)" ng-disabled="$first" title="increase this rule's priority"><span class="fa fa-arrow-up fa-lg"></span></button>
+                <button class="btn btn-info" ng-click="moveRule($index, 1)" ng-disabled="$last" title="decrease this rule's priority"><span class="fa fa-arrow-down fa-lg"></span></button>
               </div>
             </div>
 


### PR DESCRIPTION
Rules at the top have highest priority, so "↑" means "increase", "↓" means "decrease".